### PR TITLE
Removed emojis from the message

### DIFF
--- a/src/main/kotlin/net/perfectdreams/loritta/helper/utils/gotolangchannel/GoToCorrectLanguageChannel.kt
+++ b/src/main/kotlin/net/perfectdreams/loritta/helper/utils/gotolangchannel/GoToCorrectLanguageChannel.kt
@@ -54,6 +54,9 @@ class GoToCorrectLanguageChannel(val m: LorittaHelper) {
                     event.message.mentionedChannels.forEach {
                         newMessage = newMessage.replace(it.asMention, "")
                     }
+                    event.message.emotes.forEach {
+                        newMessage = newMessage.replace(it.asMention, "")
+                    }
                     newMessage
                 }
                 .let { stripLinks(it) }


### PR DESCRIPTION
This pull request removes all emojis from the message to be analyzed.

I find this useful because today I saw a staff member on the support channel who sent an emoji with an English name and then Loritta Helper told him to go to the correct channel.