### PR TITLE
Add support for commas in the user ID list in `/loritools` LoriBan-related commands

### DIFF
--- a/src/main/kotlin/net/perfectdreams/loritta/helper/interactions/commands/vanilla/LoriToolsCommand.kt
+++ b/src/main/kotlin/net/perfectdreams/loritta/helper/interactions/commands/vanilla/LoriToolsCommand.kt
@@ -226,6 +226,7 @@ class LoriToolsCommand(val helper: LorittaHelper) : SlashCommandDeclarationWrapp
             context.deferChannelMessage(true)
 
             val userIds = args[options.userIds]
+                .replace(",", "")
                 .split(" ")
                 .mapNotNull { it.toLongOrNull() }
                 .toSet()
@@ -273,6 +274,7 @@ class LoriToolsCommand(val helper: LorittaHelper) : SlashCommandDeclarationWrapp
             context.deferChannelMessage(true)
 
             val userIds = args[options.userIds]
+                .replace(",", "")
                 .split(" ")
                 .mapNotNull { it.toLongOrNull() }
                 .toSet()
@@ -319,6 +321,7 @@ class LoriToolsCommand(val helper: LorittaHelper) : SlashCommandDeclarationWrapp
             context.deferChannelMessage(true)
 
             val userIds = args[options.userIds]
+                .replace(",", "")
                 .split(" ")
                 .mapNotNull { it.toLongOrNull() }
                 .toSet()
@@ -425,6 +428,7 @@ class LoriToolsCommand(val helper: LorittaHelper) : SlashCommandDeclarationWrapp
 
         override suspend fun executeHelper(context: ApplicationCommandContext, args: SlashCommandArguments) {
             val userIds = args[options.userIds]
+                .replace(",", "")
                 .split(" ")
                 .mapNotNull { it.toLongOrNull() }
                 .toSet()


### PR DESCRIPTION
Permitir que sejam aceitos inputs nos comandos de /loritools loriban como estes:

1171288877873500244, 1038495066358030376, 1163130752662253598